### PR TITLE
Ensure workspaces key exists in parent package.json (#3989)

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -140,6 +140,9 @@ const getMonorepoPkgPaths = () => {
   if (monoPkgPath) {
     // get monorepo config from yarn workspace
     const pkgPatterns = require(monoPkgPath).workspaces;
+    if (pkgPatterns == null) {
+      return [];
+    }
     const pkgPaths = findPkgs(path.dirname(monoPkgPath), pkgPatterns);
     // only include monorepo pkgs if app itself is included in monorepo
     if (pkgPaths.indexOf(appDirectory) !== -1) {


### PR DESCRIPTION
* add default value for globPatterns

without this, the latest alpha broke on start
```
/Users/adeviankakrisnafadlil/Projects/eurecah/node_modules/react-scripts/config/paths.js:130
    .reduce(
     ^

TypeError: Cannot read property 'reduce' of undefined
    at findPkgs (/Users/adeviankakrisnafadlil/Projects/eurecah/node_modules/react-scripts/config/paths.js:130:6)
    at getMonorepoPkgPaths (/Users/adeviankakrisnafadlil/Projects/eurecah/node_modules/react-scripts/config/paths.js:143:22)
    at Object.<anonymous> (/Users/adeviankakrisnafadlil/Projects/eurecah/node_modules/react-scripts/config/paths.js:155:55)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
error Command failed with exit code 1.
```

* also check for pkgPatterns for null

* Update paths.js

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
